### PR TITLE
 feat(delete property) Implement delete endpoint with db

### DIFF
--- a/server/control/property-control.js
+++ b/server/control/property-control.js
@@ -108,19 +108,19 @@ class Property {
         }
         else res.status(404).send({ status: 404, message: "Property not found" });
     }
-    static delete(req, res) {
-        const isProperty = property.find(p => p.id == req.params.id);
-        if (isProperty) {
-            res.status(200).send({
-                status: "success",
-                message: 'deleted successfully',
-                data: isProperty
-            });
-            const indexes = property.indexOf(isProperty);
-            property.splice(indexes, 1);
-        } else {
-            res.status(404).send({ status: 404, message: "Property not found" });
-        }
+    static async delete(req, res) {
+        const id = parseInt(req.params.id);
+        const emails = req.payload.email;
+        try{
+        const findProperty = await executeQuery(queries[1].getOne, [id]);        
+        if(findProperty.length!==0){
+            if(findProperty[0].owner == emails){
+                res.status(200).send({status:200, message:'deleted'});
+            }else return res.status(403).send({status:403, error:'Not your property'});
+        }else return res.status(404).send({status:404,error:'Property not found'});
+    }catch(e){
+        res.status(400).send(e.message);
+    }
     }
 }
 export default Property;

--- a/server/control/user_control.js
+++ b/server/control/user_control.js
@@ -57,17 +57,17 @@ class User {
            console.log()
            if (aUser[0].email) {
                if(validPass){
-                    const token  = jwt.sign({email:aUser[0].email}, process.env.secretkey);
+                   const token = jwt.sign({ email: aUser[0].email}, process.env.secretkey);
                     const results = await executeQuery(queries[0].login, [email]);
                     res.status(200).send({
                         status:200, 
-                        token, 
+                        token,
                         data: {
                             email:results[0].email,
                             firstname:results[0].first_name,
                             lastname:results[0].last_name,
                             phoneNumber:results[0].phonenumber,
-                            address:results[0].address
+                            address:results[0].address,
                         }
                     });
                 }else return res.status(401).send({status:401,error:'Wrong Password'});

--- a/server/database/MyQueries.js
+++ b/server/database/MyQueries.js
@@ -1,18 +1,22 @@
 let queries = [
-{
-    create:`INSERT INTO users (email, first_name, last_name, password, phoneNumber, address) VALUES($1,$2,$3,$4,$5,$6) RETURNING *`,
-    isExist:`SELECT * FROM users where email = $1`,
-    login: `SELECT * FROM users WHERE email = $1`,// when he logs in return data associated with the email
-},
-{
-    create: `INSERT INTO properties (owner, price, state, city, address,type,image) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
-    update: `UPDATE properties SET price = $2, state = $3 , city = $4, address = $5 ,type = $6 image = $7 WHERE id = $1`,
-    markSold: `UPDATE properties SET status = $1 WHERE id = $1`,
-    undoMarkSold: `UPDATE properties SET status = $1 WHERE id = $1`,
-    delete:`DELETE FROM properties WHERE id = $1`,
-    getAll: `SELECT * FROM properties`,
-    getType: `SELECT * FROM properties WHERE type = $1`,
-    getOne: `SELECT * FROM properties WHERE id = $1`
-}
+
+    {
+        create:`INSERT INTO users (email, first_name, last_name, password, phoneNumber, address) VALUES($1,$2,$3,$4,$5,$6) RETURNING *`,
+        isExist:`SELECT * FROM users where email = $1`,
+        login: `SELECT * FROM users WHERE email = $1`,// when he logs in return data associated with the email
+        isAdmin: `SELECT * FROM users WHERE isAdmin = true`
+    },
+    {
+        create: `INSERT INTO properties (owner, price, state, city, address,type,image) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+        update: `UPDATE properties SET price = $2, state = $3 , city = $4, address = $5 ,type = $6 image = $7 WHERE id = $1`,
+        markSold: `UPDATE properties SET status = $1 WHERE id = $1`,
+        undoMarkSold: `UPDATE properties SET status = $1 WHERE id = $1`,
+        delete:`DELETE FROM properties WHERE id = $1`,
+        getAll: `SELECT * FROM properties`,
+        getType: `SELECT * FROM properties WHERE type = $1`,
+        getOne: `SELECT * FROM properties WHERE id = $1`,
+        isOwner: `SELECT * FROM properties WHERE owner = $1`
+    }
+
 ]
 export default queries;

--- a/server/helper/admin.js
+++ b/server/helper/admin.js
@@ -1,0 +1,5 @@
+function admin(req, res, next) {
+    if (!req.user.isAdmin) { return res.status(403).send({ status: 403, message: "Forbidden, you are not allowed!" }); }
+    next();
+}
+export default admin;

--- a/server/helper/authentication.js
+++ b/server/helper/authentication.js
@@ -8,7 +8,6 @@ class Tokens{
     static async authenticate(req, res, next) {
         const token = req.header('x-token');
         if (!token) return res.status(401).send({ status: 401, error: 'Access Denied. We need a token' });
-
         try {
             const payload = jwt.verify(token, process.env.secretKey);
             req.payload = payload;

--- a/server/routes/property-route.js
+++ b/server/routes/property-route.js
@@ -6,7 +6,7 @@ import flag from '../control/flag-control';
 import validFlag from '../validations/flagValidations';
 import cloudinary from '../helper/cloudinary';
 import tokens from '../helper/authentication';
-
+import admin from '../helper/admin';
 const router = express.Router();
 
 const { createProperty } = validateProperty;
@@ -18,7 +18,7 @@ router.patch('/property/:id',createProperty,property.updateProperty);
 router.patch('/property/:id/sold', property.markSold);
 router.get('/property', property.allProperties)
 router.get('/property/:id', property.specificProperty);
-router.delete('/property/:id', property.delete);
+router.delete('/property/:id', authenticate,property.delete);
 
 export default router;
 


### PR DESCRIPTION
#### What does this PR do?
It creates a delete endpoint using PostgreSQL database

#### Description of Task to be completed
- It implements the delete endpoint with persistence
- It adds SQL queries to sign the user in
- It adds authentication of the user to know of he is the owner of the property

#### How should this be manually tested?
- Make sure the tables are created , if not run **npm run db** to create tables specified in my table.js file
- Start the server by running **npm start**
- In POSTMAN, create a property with any user. grab the token in the headers and run this endpoint: localhost:5000/api/v1/property/:id(property id)  in the headers, paste the token you retrieved from the create property endpoint and send request. If it is the right token and the right property it should respond with a 200 HTTP status code, else it should return a relevant error message

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#167358884](https://www.pivotaltracker.com/story/show/167358884)
